### PR TITLE
Task deletion

### DIFF
--- a/src/main/java/com/task/Security/SecurityConfig.java
+++ b/src/main/java/com/task/Security/SecurityConfig.java
@@ -15,6 +15,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/tasks/create").permitAll()
                         .requestMatchers("/api/tasks/{id}/status").permitAll()
+                        .requestMatchers("/api/tasks/{id}/delete").permitAll()
                         .anyRequest().authenticated()
                 );
         return http.build();

--- a/src/main/java/com/task/entities/ListObject.java
+++ b/src/main/java/com/task/entities/ListObject.java
@@ -21,7 +21,7 @@ public class ListObject {
     @NotBlank(message = "Title is mandatory")
     private String title;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "task_id", referencedColumnName = "id")
     @JsonIgnore
     @JsonBackReference

--- a/src/main/java/com/task/manager/TaskActions.java
+++ b/src/main/java/com/task/manager/TaskActions.java
@@ -3,11 +3,13 @@ package com.task.manager;
 import com.task.DTO.ListObjectRequest;
 import com.task.entities.ListObject;
 import com.task.entities.TaskTable;
+import com.task.repositories.TaskRepository;
 import com.task.repositories.TaskTableRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 
 import java.util.Optional;
 import java.time.LocalDateTime;
@@ -18,7 +20,8 @@ public class TaskActions {
 
     @Autowired
     private TaskTableRepository taskTableRepository;  // השתמש ב-TaskTableRepository
-
+    @Autowired
+    private TaskRepository taskRepository;
     @PostMapping("/create")
     public void createTask(@RequestBody ListObjectRequest request) {
         ListObject listObject = new ListObject();
@@ -47,4 +50,14 @@ public class TaskActions {
         }
     }
 
+    @DeleteMapping("/{id}/delete")
+    public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
+        if (taskTableRepository.existsById(id)) {
+            taskRepository.deleteById(id);
+            taskTableRepository.deleteById(id);
+            return ResponseEntity.noContent().build(); // 204 No Content
+        } else {
+            return ResponseEntity.notFound().build(); // 404 Not Found
+        }
+    }
 }


### PR DESCRIPTION
Added a feature to allow users to delete tasks by their ID. A DELETE endpoint was created at /{id}/delete, where if the task exists, it is deleted from both taskRepository and taskTableRepository. If the task is successfully deleted, the response is 204 No Content; if not found, the response is 404 Not Found.